### PR TITLE
feat: Add reusable GitHub Actions for Go CI/CD

### DIFF
--- a/.github/actions/go/build/action.yaml
+++ b/.github/actions/go/build/action.yaml
@@ -1,0 +1,33 @@
+name: 'Go Build'
+description: 'Compiles Go packages and binaries'
+inputs:
+  working-directory:
+    description: 'Directory where Go code is located'
+    required: false
+    default: '.'
+  packages:
+    description: 'Go packages or main file to build'
+    required: false
+    default: './...'
+  output:
+    description: 'Output binary path/name'
+    required: false
+    default: ''
+  flags:
+    description: 'Additional flags for go build (e.g. -ldflags="-s -w")'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Build
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        OUT_FLAG=""
+        if [ -n "${{ inputs.output }}" ]; then
+          OUT_FLAG="-o ${{ inputs.output }}"
+        fi
+        
+        go build -v $OUT_FLAG ${{ inputs.flags }} ${{ inputs.packages }}

--- a/.github/actions/go/lint/action.yaml
+++ b/.github/actions/go/lint/action.yaml
@@ -1,0 +1,25 @@
+name: 'Go Lint'
+description: 'Runs static analysis (linting) on Go code'
+inputs:
+  working-directory:
+    description: 'Directory where Go code is located'
+    required: false
+    default: '.'
+  golangci-lint-version:
+    description: 'Version of golangci-lint to use'
+    required: false
+    default: 'v1.60'
+  args:
+    description: 'Arguments to pass to golangci-lint'
+    required: false
+    default: '--timeout=5m'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: ${{ inputs.golangci-lint-version }}
+        working-directory: ${{ inputs.working-directory }}
+        args: ${{ inputs.args }}

--- a/.github/actions/go/releaser/action.yaml
+++ b/.github/actions/go/releaser/action.yaml
@@ -1,0 +1,25 @@
+name: 'GoReleaser'
+description: 'Builds, packages, and publishes Go projects using GoReleaser'
+inputs:
+  version:
+    description: 'GoReleaser version to use (e.g., "latest" or "v2.0.0")'
+    required: false
+    default: 'latest'
+  args:
+    description: 'Arguments to pass to GoReleaser'
+    required: false
+    default: 'release --clean'
+  github-token:
+    description: 'GitHub token with contents write permissions'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        version: ${{ inputs.version }}
+        args: ${{ inputs.args }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/go/setup/action.yaml
+++ b/.github/actions/go/setup/action.yaml
@@ -1,0 +1,26 @@
+name: 'Go Setup'
+description: 'Sets up a Go environment with caching support'
+inputs:
+  go-version:
+    description: 'The Go version to install'
+    required: false
+    default: ''
+  go-version-file:
+    description: 'Path to a go.mod file to read the Go version from'
+    required: false
+    default: ''
+  working-directory:
+    description: 'Working directory for cache validation'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        go-version-file: ${{ inputs.go-version-file != '' && inputs.go-version-file || format('{0}/go.mod', inputs.working-directory) }}
+        cache: true
+        cache-dependency-path: ${{ inputs.go-version-file != '' && inputs.go-version-file || format('{0}/go.sum', inputs.working-directory) }}

--- a/.github/actions/go/test/action.yaml
+++ b/.github/actions/go/test/action.yaml
@@ -1,0 +1,38 @@
+name: 'Go Test'
+description: 'Runs Go tests with coverage and race detection'
+inputs:
+  working-directory:
+    description: 'Directory where Go code is located'
+    required: false
+    default: '.'
+  race:
+    description: 'Enable race detector ("true" or "false")'
+    required: false
+    default: 'true'
+  coverage:
+    description: 'Generate code coverage profile ("true" or "false")'
+    required: false
+    default: 'true'
+  packages:
+    description: 'Go packages to test'
+    required: false
+    default: './...'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Tests
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        RACE_FLAG=""
+        if [ "${{ inputs.race }}" = "true" ]; then
+          RACE_FLAG="-race"
+        fi
+        
+        COVER_FLAG=""
+        if [ "${{ inputs.coverage }}" = "true" ]; then
+          COVER_FLAG="-coverprofile=coverage.out -covermode=atomic"
+        fi
+        
+        go test -v $RACE_FLAG $COVER_FLAG ${{ inputs.packages }}

--- a/.github/workflows/rwf-go-build-and-publish.yaml
+++ b/.github/workflows/rwf-go-build-and-publish.yaml
@@ -1,0 +1,70 @@
+name: go-build-and-publish
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: 'Directory where Go code is located'
+        type: string
+        required: false
+        default: '.'
+      go_version:
+        description: 'Go version to install'
+        type: string
+        required: false
+        default: ''
+      packages:
+        description: 'Go packages or main file to build'
+        type: string
+        required: false
+        default: './...'
+      output:
+        description: 'Output binary path/name'
+        type: string
+        required: false
+        default: ''
+      flags:
+        description: 'Additional flags for go build'
+        type: string
+        required: false
+        default: ''
+      publish_tag:
+        description: 'Git tag to publish release assets to (leave empty to build only)'
+        type: string
+        required: false
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: ./.github/actions/go/setup
+      with:
+        go-version: ${{ inputs.go_version }}
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Build Go binary
+      uses: ./.github/actions/go/build
+      with:
+        working-directory: ${{ inputs.working_directory }}
+        packages: ${{ inputs.packages }}
+        output: ${{ inputs.output }}
+        flags: ${{ inputs.flags }}
+
+    - name: Publish Go binary to GitHub Release
+      if: ${{ inputs.publish_tag != '' && inputs.output != '' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ inputs.publish_tag }}
+        files: ${{ inputs.working_directory }}/${{ inputs.output }}

--- a/.github/workflows/rwf-go-releaser.yaml
+++ b/.github/workflows/rwf-go-releaser.yaml
@@ -1,0 +1,58 @@
+name: go-releaser
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: 'Directory containing GoReleaser configuration'
+        type: string
+        required: false
+        default: '.'
+      go_version:
+        description: 'Go version to install'
+        type: string
+        required: false
+        default: ''
+      goreleaser_version:
+        description: 'GoReleaser version to use'
+        type: string
+        required: false
+        default: 'latest'
+      args:
+        description: 'Arguments to pass to GoReleaser'
+        type: string
+        required: false
+        default: 'release --clean'
+    secrets:
+      token:
+        description: 'GitHub token with contents write permissions. Defaults to github.token if not provided.'
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: ./.github/actions/go/setup
+      with:
+        go-version: ${{ inputs.go_version }}
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Run GoReleaser
+      uses: ./.github/actions/go/releaser
+      with:
+        version: ${{ inputs.goreleaser_version }}
+        args: ${{ inputs.args }}
+        github-token: ${{ secrets.token || github.token }}

--- a/.github/workflows/rwf-go-static-analysis.yaml
+++ b/.github/workflows/rwf-go-static-analysis.yaml
@@ -1,0 +1,46 @@
+name: go-static-analysis
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: 'Directory where Go code is located'
+        type: string
+        required: false
+        default: '.'
+      go_version:
+        description: 'Go version to install'
+        type: string
+        required: false
+        default: ''
+      golangci_lint_version:
+        description: 'Version of golangci-lint to use'
+        type: string
+        required: false
+        default: 'v1.60'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: ./.github/actions/go/setup
+      with:
+        go-version: ${{ inputs.go_version }}
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Run Go Lint
+      uses: ./.github/actions/go/lint
+      with:
+        working-directory: ${{ inputs.working_directory }}
+        golangci-lint-version: ${{ inputs.golangci_lint_version }}

--- a/.github/workflows/rwf-go-test.yaml
+++ b/.github/workflows/rwf-go-test.yaml
@@ -1,0 +1,58 @@
+name: go-test
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: 'Directory where Go code is located'
+        type: string
+        required: false
+        default: '.'
+      go_version:
+        description: 'Go version to install'
+        type: string
+        required: false
+        default: ''
+      race:
+        description: 'Enable race detector'
+        type: boolean
+        required: false
+        default: true
+      coverage:
+        description: 'Generate code coverage profile'
+        type: boolean
+        required: false
+        default: true
+      packages:
+        description: 'Go packages to test'
+        type: string
+        required: false
+        default: './...'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: ./.github/actions/go/setup
+      with:
+        go-version: ${{ inputs.go_version }}
+        working-directory: ${{ inputs.working_directory }}
+
+    - name: Run Go Tests
+      uses: ./.github/actions/go/test
+      with:
+        working-directory: ${{ inputs.working_directory }}
+        race: ${{ inputs.race }}
+        coverage: ${{ inputs.coverage }}
+        packages: ${{ inputs.packages }}

--- a/.github/workflows/wf-go-cicd.yaml
+++ b/.github/workflows/wf-go-cicd.yaml
@@ -1,0 +1,34 @@
+name: wf-go-cicd
+
+on:
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  go-static-analysis:
+    uses: ./.github/workflows/rwf-go-static-analysis.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+
+  go-test:
+    uses: ./.github/workflows/rwf-go-test.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+      race: true
+      coverage: true
+
+  go-build:
+    needs: [ go-static-analysis, go-test ]
+    uses: ./.github/workflows/rwf-go-build-and-publish.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+      packages: '.'
+      output: 'hello-world-bin'
+      publish_tag: ''

--- a/.github/workflows/wf-verge-tag.yaml
+++ b/.github/workflows/wf-verge-tag.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: ./.github/workflows/rwf-verge-tag.yaml
     secrets: inherit
     with:
-      verge_arguments: ${{ github.ref_name == github.event.repository.default_branch && '--kind final' || '' }}
+      verge_arguments: ${{ github.ref_name == github.event.repository.default_branch && '--kind patch' || '' }}
       prune_dev_tags: ${{ github.ref_name == github.event.repository.default_branch }}
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ While this repository is optimized and primarily built for GitHub Actions, we al
 * **[GitHub Actions & Reusable Workflows](./platforms/github/)** (Primary Focus)
 * [Bamboo Plans](./platforms/bamboo/)
 * [Jenkins Pipelines](./platforms/jenkins/)
+

--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ While this repository is optimized and primarily built for GitHub Actions, we al
 * **[GitHub Actions & Reusable Workflows](./platforms/github/)** (Primary Focus)
 * [Bamboo Plans](./platforms/bamboo/)
 * [Jenkins Pipelines](./platforms/jenkins/)
-

--- a/docs/github/actions/README.md
+++ b/docs/github/actions/README.md
@@ -21,3 +21,10 @@ This directory contains usage documentation for each local GitHub Action in [../
 - [terraform/security](./terraform/security.md)
 - [terraform/lint](./terraform/lint.md)
 - [terraform/delete-state](./terraform/delete-state.md)
+- [go/setup](./go/setup.md)
+- [go/lint](./go/lint.md)
+- [go/test](./go/test.md)
+- [go/build](./go/build.md)
+- [go/releaser](./go/releaser.md)
+
+

--- a/docs/github/actions/go/build.md
+++ b/docs/github/actions/go/build.md
@@ -1,0 +1,33 @@
+# build
+
+This document describes the local composite action to **compile Go packages**.
+
+Action file: [../../../../.github/actions/go/build/action.yaml](../../../../.github/actions/go/build/action.yaml)
+
+## Purpose
+
+Compiles Go packages and generates production binaries, supporting customized output files and build flags.
+
+## When To Use
+
+Use this action in build pipelines, pre-release pipelines, or CD pipelines to produce compiled binaries from your Go code.
+
+## Usage
+
+```yaml
+- name: Build Go Binary
+  uses: ./.github/actions/go/build
+  with:
+    working-directory: '.'
+    packages: './cmd/myapp'
+    output: 'myapp-binary'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working-directory` | No | `.` | Directory where Go code is located. |
+| `packages` | No | `./...` | The Go packages or entrypoint file to compile. |
+| `output` | No | empty string | The relative path/filename for the built output binary. |
+| `flags` | No | empty string | Additional compiler flags to pass (e.g. `-ldflags="-s -w"`). |

--- a/docs/github/actions/go/lint.md
+++ b/docs/github/actions/go/lint.md
@@ -1,0 +1,36 @@
+# lint
+
+This document describes the local composite action to run **golangci-lint** on Go source code.
+
+Action file: [../../../../.github/actions/go/lint/action.yaml](../../../../.github/actions/go/lint/action.yaml)
+
+## Purpose
+
+Runs static analysis and code style checks on Go code using `golangci-lint` to catch bugs, formatting issues, and enforce best practices.
+
+## When To Use
+
+Use this action in pull requests and CI flows to validate code quality before merging.
+
+## Usage
+
+```yaml
+- name: Run Go Lint
+  uses: ./.github/actions/go/lint
+  with:
+    working-directory: '.'
+    golangci-lint-version: 'v1.60'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working-directory` | No | `.` | Directory where Go code is located. |
+| `golangci-lint-version` | No | `v1.60` | Version of `golangci-lint` to use. |
+| `args` | No | `--timeout=5m` | Arguments to pass to the `golangci-lint` CLI. |
+
+## Notes
+
+- Uses `golangci/golangci-lint-action@v6` which has built-in smart caching for linting artifacts.
+- Relies on a `.golangci.yml` file if one is present in the repository, otherwise falls back to defaults.

--- a/docs/github/actions/go/releaser.md
+++ b/docs/github/actions/go/releaser.md
@@ -1,0 +1,35 @@
+# releaser
+
+This document describes the local composite action to run **GoReleaser**.
+
+Action file: [../../../../.github/actions/go/releaser/action.yaml](../../../../.github/actions/go/releaser/action.yaml)
+
+## Purpose
+
+Runs GoReleaser to compile Go binaries for multiple architectures/operating systems, package them, and publish release artifacts (including checksums and changelogs) to GitHub Releases.
+
+## When To Use
+
+Use this action in CD (Continuous Delivery) release pipelines to automate the distribution of Go applications.
+
+## Usage
+
+```yaml
+- name: Run GoReleaser
+  uses: ./.github/actions/go/releaser
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `version` | No | `latest` | The GoReleaser version to use (e.g. `latest` or `v2.0.0`). |
+| `args` | No | `release --clean` | Arguments to pass to the GoReleaser CLI. |
+| `github-token` | Yes | none | GitHub token with write permissions to create and update releases. |
+
+## Notes
+
+- Requires a valid Go environment to be set up on the runner first (e.g. using the Go `setup` action).
+- Assumes a GoReleaser configuration file (e.g. `.goreleaser.yaml`) is located in the working directory or root of the repository.

--- a/docs/github/actions/go/setup.md
+++ b/docs/github/actions/go/setup.md
@@ -1,0 +1,36 @@
+# setup
+
+This document describes the local composite action to set up the **Go environment** on the runner.
+
+Action file: [../../../../.github/actions/go/setup/action.yaml](../../../../.github/actions/go/setup/action.yaml)
+
+## Purpose
+
+Sets up a specific Go environment on the runner, including enabling dependency caching natively.
+
+## When To Use
+
+Use this action to initialize Go on the runner before compiling, testing, or linting Go code.
+
+## Usage
+
+```yaml
+- name: Set up Go
+  uses: ./.github/actions/go/setup
+  with:
+    go-version: '1.22'
+    working-directory: '.'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `go-version` | No | empty string | The Go version to install (e.g. `1.22`). |
+| `go-version-file` | No | empty string | Path to a `go.mod` file to read the Go version from. Defaults to `<working-directory>/go.mod` if left empty. |
+| `working-directory` | No | `.` | Working directory used for fallback `go.mod` path and dependency caching validation. |
+
+## Notes
+
+- Uses `actions/setup-go@v5` under the hood.
+- Automatically enables caching for Go modules based on `go.sum` under the working directory.

--- a/docs/github/actions/go/test.md
+++ b/docs/github/actions/go/test.md
@@ -1,0 +1,37 @@
+# test
+
+This document describes the local composite action to run **Go unit tests**.
+
+Action file: [../../../../.github/actions/go/test/action.yaml](../../../../.github/actions/go/test/action.yaml)
+
+## Purpose
+
+Runs unit and integration tests across Go packages with optional race detection and code coverage file generation.
+
+## When To Use
+
+Use this action during pull requests or push CI pipelines to guarantee functional correctness of Go applications.
+
+## Usage
+
+```yaml
+- name: Run Go Tests
+  uses: ./.github/actions/go/test
+  with:
+    working-directory: '.'
+    race: 'true'
+    coverage: 'true'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working-directory` | No | `.` | Directory where Go code is located. |
+| `race` | No | `true` | Enable Go race detector (string `true` or `false`). |
+| `coverage` | No | `true` | Enable code coverage profiling and output `coverage.out` (string `true` or `false`). |
+| `packages` | No | `./...` | The Go packages to run tests on. |
+
+## Notes
+
+- Output coverage reports are saved as `coverage.out` inside the `working-directory` under atomic mode, perfect for uploading to Codecov or other coverage metrics trackers.

--- a/docs/github/guides/README.md
+++ b/docs/github/guides/README.md
@@ -25,5 +25,9 @@ Browse the guides below based on your target stack or deployment use case:
 * **[Python Static Analysis](./python-static-analysis.md)**: Implement automated code quality checks, style guides (flake8, black, mypy), and pytest unit testing.
 * **[Python Package Pipeline](./python-package-pipeline.md)**: Compile and publish source distributions (wheels and tarballs) to PyPI or corporate package repositories.
 
+### 🐹 Go Applications & Binaries
+* **[Go CI/CD Pipeline Guide](./go-pipeline.md)**: Set up automated quality assurance (golangci-lint, tests with race detection and coverage) and production binary builds published directly to GitHub Releases.
+
 ### 🤖 Automation & Pull Requests
 * **[Pull Request Automation](./pr-automation.md)**: Automate background synchronization tasks, track drifitng files, commit changes, and open pre-formatted Pull Requests.
+

--- a/docs/github/guides/go-pipeline.md
+++ b/docs/github/guides/go-pipeline.md
@@ -55,7 +55,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/rwf-verge-tag.yaml
     with:
-      verge_arguments: '--kind final'
+      verge_arguments: '--kind patch'
       prune_dev_tags: true
 
   # Stage 4: Build & Publish (compiles binary and publishes it to the release)
@@ -117,7 +117,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/rwf-verge-tag.yaml
     with:
-      verge_arguments: '--kind final'
+      verge_arguments: '--kind patch'
       prune_dev_tags: true
 
   # Stage 4: Professional Release via GoReleaser

--- a/docs/github/guides/go-pipeline.md
+++ b/docs/github/guides/go-pipeline.md
@@ -1,0 +1,209 @@
+# Go CI/CD Pipeline Guide
+
+This guide describes how to implement an end-to-end automated quality control, testing, and deployment (release publishing) pipeline for Go applications using reusable GitHub workflows. It also incorporates dynamic semantic version resolution using the **Verge CLI** and offers options for both simple builds and professional multi-platform packaging via **GoReleaser**.
+
+## Use Case
+
+Go is natively compiled, making static analysis (linting), unit testing, and binary compilation key parts of the CI/CD lifecycle. An automated Go pipeline should:
+1. **Lint and Check**: Use static analysis tools like `golangci-lint` to detect potential bugs, style issues, and performance bottlenecks.
+2. **Unit Test**: Run tests with Go's built-in toolchain, checking for race conditions and measuring coverage.
+3. **Resolve Version**: Dynamically calculate the next Semantic Version (SemVer) based on commit history or pull request context without manual intervention.
+4. **Deploy & Publish**: Compile optimized binaries and publish them as release assets on GitHub under the dynamically calculated version.
+
+---
+
+## Go CI/CD End-to-End Workflow (Simple Build)
+
+Below is a complete recipe combining Go reusable workflows and Verge tagging into a single pipeline.
+*   **On Pull Request**: Runs linting and unit tests in parallel.
+*   **On Push to Main**: Runs linting and tests, dynamically calculates the next SemVer using the Verge tag provider, builds the optimized Go binaries, and publishes them to a new GitHub Release.
+
+```yaml
+name: Go CI/CD Pipeline
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths: [ '**.go', 'go.mod', 'go.sum' ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  # Stage 1: Static Analysis
+  go-static-analysis:
+    uses: ./.github/workflows/rwf-go-static-analysis.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+
+  # Stage 2: Unit Testing (runs in parallel with static analysis)
+  go-test:
+    uses: ./.github/workflows/rwf-go-test.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+      race: true
+      coverage: true
+
+  # Stage 3: Resolve Version & Tag (only runs on push to main after CI passes)
+  resolve-version:
+    needs: [ go-static-analysis, go-test ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/rwf-verge-tag.yaml
+    with:
+      verge_arguments: '--kind final'
+      prune_dev_tags: true
+
+  # Stage 4: Build & Publish (compiles binary and publishes it to the release)
+  go-build-deploy:
+    needs: [ resolve-version ]
+    uses: ./.github/workflows/rwf-go-build-and-publish.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+      packages: './cmd/myapp'
+      output: 'myapp-linux-amd64'
+      flags: '-ldflags="-s -w"' # Strip debugging symbols for smaller binaries
+      publish_tag: ${{ needs.resolve-version.outputs.version }}
+```
+
+---
+
+## Alternative CD: Professional Multi-Platform Releases via GoReleaser
+
+For mature open-source tools or production systems requiring multi-platform compilation (Windows, macOS, Linux, ARM/AMD64), package archives (tar.gz/zip), checksum generation, and structured changelogs, we recommend **GoReleaser**.
+
+Here is the CD recipe substituting the simple build-and-publish stage with our reusable GoReleaser workflow:
+
+```yaml
+name: Go CI/CD Pipeline with GoReleaser
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths: [ '**.go', 'go.mod', 'go.sum' ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  # Stage 1: Static Analysis
+  go-static-analysis:
+    uses: ./.github/workflows/rwf-go-static-analysis.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+
+  # Stage 2: Unit Testing
+  go-test:
+    uses: ./.github/workflows/rwf-go-test.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+      race: true
+      coverage: true
+
+  # Stage 3: Resolve Version & Tag (runs on push to main)
+  # GoReleaser operates on the git tag created in this step!
+  resolve-version:
+    needs: [ go-static-analysis, go-test ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/rwf-verge-tag.yaml
+    with:
+      verge_arguments: '--kind final'
+      prune_dev_tags: true
+
+  # Stage 4: Professional Release via GoReleaser
+  go-releaser-deploy:
+    needs: [ resolve-version ]
+    uses: ./.github/workflows/rwf-go-releaser.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+      goreleaser_version: 'latest'
+      args: 'release --clean'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### GoReleaser Configuration File Setup
+
+To use GoReleaser, you must create a configuration file named `.goreleaser.yaml` in the root of your Go project. Below is an example configuration modeled after the `verge` repository:
+
+```yaml
+version: 2
+project_name: myapp
+builds:
+  - id: myapp
+    main: ./cmd/myapp
+    binary: myapp
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Commit={{.Commit}}
+      - -X main.Date={{.Date}}
+archives:
+  - format: tar.gz
+    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+```
+
+---
+
+## How the Components Work
+
+### 1. Static Analysis (`rwf-go-static-analysis.yaml`)
+This workflow calls the custom Go `setup` and `lint` actions:
+- Sets up Go using `actions/setup-go` with caching enabled.
+- Runs `golangci-lint` which runs multiple standard linters concurrently (`errcheck`, `gosimple`, `govet`, `staticcheck`, etc.).
+- Auto-caches linter dependencies and execution state for fast subsequent runs.
+
+### 2. Unit Testing (`rwf-go-test.yaml`)
+This workflow runs the package test suite:
+- Validates code execution and catches memory errors using the `-race` detector flag.
+- Generates code coverage metrics (`coverage.out`) that can be exported or validated against a code quality gate.
+
+### 3. Version Resolution (`rwf-verge-tag.yaml`)
+Kept isolated as its own reusable stage, the Verge tagging workflow:
+- Connects to the repository and calculates the next logical release version.
+- Automatically generates and pushes the git tags.
+- Cleans up ephemeral developer pre-release tags once the final version is tagged.
+- Publishes the final tag name as an output parameter (`version`).
+
+### 4. Build & Publish (`rwf-go-build-and-publish.yaml`)
+This workflow compiles your application and publishes it:
+- Uses `go build` with specified target files/packages, output naming, and linker flags (like `-ldflags="-s -w"` to produce highly optimized, stripped binaries).
+- Feeds the dynamically generated tag output from the `resolve-version` job (`${{ needs.resolve-version.outputs.version }}`) into the `publish_tag` input.
+- Publishes the final binary to the specified GitHub Release tag via `softprops/action-gh-release@v2`.
+
+### 5. Professional Release (`rwf-go-releaser.yaml`)
+This workflow utilizes GoReleaser:
+- Performs a checkout with `fetch-depth: 0` to retrieve all historical tags, which GoReleaser requires to construct the release changelog and identify the tag.
+- Sets up Go and runs GoReleaser using the local `go/releaser` action.
+- Generates multi-architecture binaries and tarballs, creates a GitHub Release, writes a formatted changelog, and uploads checksums.
+
+---
+
+## Notes & Best Practices
+
+- **Go Version Matching**: Omit `go_version` to let the workflow automatically parse the required version directly from the project's `go.mod` file.
+- **Authentication**: Ensure the GITHUB_TOKEN has write permission for contents (`contents: write`) in order to let Verge push git tags and allow the release steps (both GoReleaser and GitHub Release) to publish assets.
+- **Workflow Isolation**: Keeping Verge versioning as an isolated job in the workflow ensures that we only incur the compile and deployment overhead after a new official tag is successfully minted.

--- a/docs/github/reusable-workflows/README.md
+++ b/docs/github/reusable-workflows/README.md
@@ -10,6 +10,12 @@ This directory contains usage documentation for each reusable GitHub Actions wor
 - [rwf-python-build-and-publish](./rwf-python-build-and-publish.md)
 - [rwf-python-static-analysis](./rwf-python-static-analysis.md)
 - [rwf-python-test](./rwf-python-test.md)
+- [rwf-go-build-and-publish](./rwf-go-build-and-publish.md)
+- [rwf-go-releaser](./rwf-go-releaser.md)
+- [rwf-go-static-analysis](./rwf-go-static-analysis.md)
+- [rwf-go-test](./rwf-go-test.md)
+
+
 - [rwf-verge-tag](./rwf-verge-tag.md)
 - [rwf-terraform-apply](./rwf-terraform-apply.md)
 - [rwf-terraform-auto-apply](./rwf-terraform-auto-apply.md)

--- a/docs/github/reusable-workflows/rwf-go-build-and-publish.md
+++ b/docs/github/reusable-workflows/rwf-go-build-and-publish.md
@@ -1,0 +1,56 @@
+# rwf-go-build-and-publish
+
+This document describes the Go building and release asset publishing reusable workflow.
+
+Reusable workflow file: [../../../.github/workflows/rwf-go-build-and-publish.yaml](../../../.github/workflows/rwf-go-build-and-publish.yaml)
+
+## Purpose
+
+Compiles Go code to a specified output binary name and optionally uploads it as a release asset to a GitHub Release.
+
+## When To Use
+
+Use this in Go deployment, CI build validation, pre-release, or CD pipelines to produce compiled binaries and optionally distribute them on GitHub Releases.
+
+## Usage
+
+```yaml
+jobs:
+  go-build:
+    uses: ./.github/workflows/rwf-go-build-and-publish.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+      packages: '.'
+      output: 'hello-world-bin'
+      publish_tag: 'v1.0.0'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working_directory` | No | `.` | Directory where Go code is located. |
+| `go_version` | No | empty string | The Go version to install. Defaults to reading from `go.mod`. |
+| `packages` | No | `./...` | The Go packages or entrypoint file to compile. |
+| `output` | No | empty string | The relative path/filename for the built output binary. |
+| `flags` | No | empty string | Additional compiler flags to pass (e.g. `-ldflags="-s -w"`). |
+| `publish_tag` | No | empty string | Git tag to publish the compiled binary to (using GitHub Release). Leave blank to compile without publishing. |
+
+## Secrets
+
+This workflow does not define any `workflow_call` secrets.
+
+## Outputs
+
+This workflow does not publish outputs.
+
+## What It Runs
+
+- Sets up Go environment via [setup action](../actions/go/setup.md).
+- Compiles package via [build action](../actions/go/build.md).
+- Uploads compiled binaries as release assets via `softprops/action-gh-release@v2`.
+
+## Notes
+
+- The bundled caller example is [../../../.github/workflows/wf-go-cicd.yaml](../../../.github/workflows/wf-go-cicd.yaml).

--- a/docs/github/reusable-workflows/rwf-go-releaser.md
+++ b/docs/github/reusable-workflows/rwf-go-releaser.md
@@ -1,0 +1,57 @@
+# rwf-go-releaser
+
+This document describes the GoReleaser reusable workflow.
+
+Reusable workflow file: [../../../.github/workflows/rwf-go-releaser.yaml](../../../.github/workflows/rwf-go-releaser.yaml)
+
+## Purpose
+
+Automates multi-platform building, packaging, checksum generation, changelog assembly, and release asset uploads using GoReleaser.
+
+## When To Use
+
+Use this in Go release CD pipelines to deploy standardized multi-architecture binaries and packages automatically.
+
+## Usage
+
+```yaml
+jobs:
+  go-releaser:
+    uses: ./.github/workflows/rwf-go-releaser.yaml
+    with:
+      working_directory: '.'
+      go_version: '1.22'
+      goreleaser_version: 'latest'
+      args: 'release --clean'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working_directory` | No | `.` | Directory containing GoReleaser configuration. |
+| `go_version` | No | empty string | The Go version to install. Defaults to reading from `go.mod`. |
+| `goreleaser_version` | No | `latest` | The GoReleaser version to install. |
+| `args` | No | `release --clean` | Arguments to pass to GoReleaser. |
+
+## Secrets
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `token` | No | `github.token` | GitHub token with contents write permissions. |
+
+## Outputs
+
+This workflow does not publish outputs.
+
+## What It Runs
+
+- Performs standard checkout with full git tags history (`fetch-depth: 0`).
+- Sets up Go environment via [setup action](../actions/go/setup.md).
+- Runs GoReleaser via [releaser action](../actions/go/releaser.md).
+
+## Notes
+
+- Requires a valid GoReleaser configuration file (e.g. `.goreleaser.yaml` or `.goreleaser.yml`) at the root of your Go module.

--- a/docs/github/reusable-workflows/rwf-go-static-analysis.md
+++ b/docs/github/reusable-workflows/rwf-go-static-analysis.md
@@ -1,0 +1,49 @@
+# rwf-go-static-analysis
+
+This document describes the Go static analysis reusable workflow.
+
+Reusable workflow file: [../../../.github/workflows/rwf-go-static-analysis.yaml](../../../.github/workflows/rwf-go-static-analysis.yaml)
+
+## Purpose
+
+Runs static analysis and lint checks using `golangci-lint` to maintain Go code quality and standard adherence.
+
+## When To Use
+
+Use this in Go pull request checks and CI runs.
+
+## Usage
+
+```yaml
+jobs:
+  go-static-analysis:
+    uses: ./.github/workflows/rwf-go-static-analysis.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working_directory` | No | `.` | Directory where Go code is located. |
+| `go_version` | No | empty string | The Go version to install. Defaults to reading from `go.mod`. |
+| `golangci_lint_version` | No | `v1.60` | Version of `golangci-lint` to use. |
+
+## Secrets
+
+This workflow does not define any `workflow_call` secrets.
+
+## Outputs
+
+This workflow does not publish outputs.
+
+## What It Runs
+
+- Sets up Go environment via [setup action](../actions/go/setup.md).
+- Runs `golangci-lint` via [lint action](../actions/go/lint.md).
+
+## Notes
+
+- The bundled caller example is [../../../.github/workflows/wf-go-cicd.yaml](../../../.github/workflows/wf-go-cicd.yaml).

--- a/docs/github/reusable-workflows/rwf-go-test.md
+++ b/docs/github/reusable-workflows/rwf-go-test.md
@@ -1,0 +1,53 @@
+# rwf-go-test
+
+This document describes the Go unit testing reusable workflow.
+
+Reusable workflow file: [../../../.github/workflows/rwf-go-test.yaml](../../../.github/workflows/rwf-go-test.yaml)
+
+## Purpose
+
+Runs unit and integration tests across Go packages with optional race detection and code coverage file generation.
+
+## When To Use
+
+Use this in Go pull request checks and CI runs alongside static analysis.
+
+## Usage
+
+```yaml
+jobs:
+  go-test:
+    uses: ./.github/workflows/rwf-go-test.yaml
+    with:
+      working_directory: tests/go/example
+      go_version: '1.22'
+      race: true
+      coverage: true
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `working_directory` | No | `.` | Directory where Go code is located. |
+| `go_version` | No | empty string | The Go version to install. Defaults to reading from `go.mod`. |
+| `race` | No | `true` | Enable Go race detector (boolean). |
+| `coverage` | No | `true` | Enable code coverage profiling and output `coverage.out` (boolean). |
+| `packages` | No | `./...` | The Go packages to run tests on. |
+
+## Secrets
+
+This workflow does not define any `workflow_call` secrets.
+
+## Outputs
+
+This workflow does not publish outputs.
+
+## What It Runs
+
+- Sets up Go environment via [setup action](../actions/go/setup.md).
+- Runs tests via [test action](../actions/go/test.md).
+
+## Notes
+
+- The bundled caller example is [../../../.github/workflows/wf-go-cicd.yaml](../../../.github/workflows/wf-go-cicd.yaml).

--- a/tests/go/example/README.md
+++ b/tests/go/example/README.md
@@ -1,0 +1,15 @@
+# hello-world (Go)
+
+A minimal example Go application used to test and demonstrate the Go CICD reusable workflows.
+
+## Usage
+
+```bash
+go run main.go
+```
+
+## Running Tests
+
+```bash
+go test -v ./...
+```

--- a/tests/go/example/go.mod
+++ b/tests/go/example/go.mod
@@ -1,0 +1,3 @@
+module github.com/armckinney/cicd/tests/go/example
+
+go 1.22

--- a/tests/go/example/main.go
+++ b/tests/go/example/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+// Greet returns a greeting message.
+func Greet(name string) string {
+	return fmt.Sprintf("Hello, %s!", name)
+}
+
+func main() {
+	fmt.Println(Greet("World"))
+}

--- a/tests/go/example/main_test.go
+++ b/tests/go/example/main_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+	expected := "Hello, World!"
+	actual := Greet("World")
+	if actual != expected {
+		t.Errorf("expected %q, got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
- Implemented Go Build action to compile Go packages and binaries.
- Added Go Lint action for static analysis using golangci-lint.
- Created GoReleaser action for building, packaging, and publishing Go projects.
- Developed Go Setup action to configure Go environment with caching.
- Introduced Go Test action to run tests with coverage and race detection.
- Created reusable workflows for Go build, release, static analysis, and testing.
- Updated documentation for each action and reusable workflow.
- Added example Go application with tests to demonstrate CI/CD workflows.